### PR TITLE
Fix work with glibc < 2.14

### DIFF
--- a/unshare.c
+++ b/unshare.c
@@ -56,6 +56,7 @@ static PyMethodDef methods[] = {
         "CLONE_NEWPID\n"
         "  CLONE_NEWNET\n"
     },
+#if __GLIBC_MINOR__ >= 14
     {"setns", _setns, METH_VARARGS,
         "setns(fd, nstype)\n\n"
         "Reassociate the calling thread with a new namespace.\n"
@@ -71,6 +72,7 @@ static PyMethodDef methods[] = {
         "  CLONE_NEWUSER fd must refer to a user namespace.\n"
         "  CLONE_NEWUTS  fd must refer to a UTS namespace.\n"
     },
+#endif
     {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
[setns](http://man7.org/linux/man-pages/man2/setns.2.html) is available since GLIBC 2.14, but for RHEL/Centos/Cloudlinux 6 maximum available version is 2.12.