### PR TITLE
Don't claim that unshare was added to util-linux "recently"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ By using `unshare()`, new and interesting features of the Linux kernel can be ex
  * Creating a new file system mount name space (`CLONE_NEWNS`)
  * Reverting other features shared from `clone()`
 
-This library provides an equivalent of the (recently added) util-linux command-line program `unshare`.
+This library provides an equivalent of the util-linux command-line program `unshare`.


### PR DESCRIPTION
unshare(1) was first included in [util-linux v2.17](https://github.com/karelzak/util-linux/blob/v2.17/docs/v2.17-ReleaseNotes), which was released on 2010-01-08.
That's over 8 years ago, which is not *recent* in my book. :)